### PR TITLE
Add NGI0 Commons Fund to our timeline.

### DIFF
--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -134,7 +134,7 @@ export default function Timeline() {
       link: "/press",
     },
     {
-      title: "OpenVoiceOS receives NGI Zero Common Fund grant",
+      title: "OpenVoiceOS receives NGI Zero Commons Fund grant",
       date: "October 2025",
       description: "OpenVoiceOS has been selected to receive a grant from the NGI Zero Commons Fund!",
       link: "https://blog.openvoiceos.org/posts/2025-10-20-ngi",

--- a/components/timeline.tsx
+++ b/components/timeline.tsx
@@ -127,17 +127,17 @@ export default function Timeline() {
       description: "Mycroft forums move to Open Conversational AI.",
     },
     {
-      title: "OpenVoiceOS get's out of beta",
-      date: "November 2024",
-      description: "OpenVoiceOS get's out of beta and is ready for the masses.",
-      link: "https://community.openconversational.ai/t/openvoiceos-0-0-8-qa-process-begins-now/15372",
-    },
-    {
       title: "OpenVoice Foundation Established",
       date: "Febuary 2025",
       description:
         "OpenVoice Foundation is established as a non-profit foundation legal entity.",
       link: "/press",
+    },
+    {
+      title: "OpenVoiceOS receives NGI Zero Common Fund grant",
+      date: "October 2025",
+      description: "OpenVoiceOS has been selected to receive a grant from the NGI Zero Commons Fund!",
+      link: "https://blog.openvoiceos.org/posts/2025-10-20-ngi",
     },
   ];
 


### PR DESCRIPTION
Also remove the beta/final news as it didn't really happen. We where ready and testing however where not there as of yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Timeline milestones refreshed: removed an outdated November 2024 event and added a new October 2025 grant milestone highlighting the NGI Zero Commons Fund award.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->